### PR TITLE
Implemented logic to dismiss splash screen after 2 seconds. user can …

### DIFF
--- a/app/src/main/java/com/sara/canwesail/view/screens/SplashScreen.kt
+++ b/app/src/main/java/com/sara/canwesail/view/screens/SplashScreen.kt
@@ -34,7 +34,9 @@ fun goToAnimatedSplashScreen(navController: NavHostController) {
 
     LaunchedEffect(key1 = true ) {
         startAnimation = true
-        delay(1000)
+        delay(2000)
+        navController.popBackStack()
+        navController.navigate(route = AppScreens.HomeScreen.name)
     }
 
     splash(navController, alphaAnimation.value)


### PR DESCRIPTION
### Description
[mplemented logic to dismiss splash screen after 2 seconds. user can still click to proceed to next screen.](https://github.com/sara-adelino/can-we-sail/commit/a9503ef3498fc8b31ce6fbf780479ce7787e71f5) 


### Type of change
- [ ] Bug fix 
- [ ] New feature
- [x] Task
- [ ] Refactoring code / Cleanup